### PR TITLE
Adding locale for correct parsing

### DIFF
--- a/app/src/main/java/net/maxbraun/mirror/Weather.java
+++ b/app/src/main/java/net/maxbraun/mirror/Weather.java
@@ -141,10 +141,10 @@ public class Weather extends DataUpdater<WeatherData> {
    * Creates the URL for a Forecast API request based on the specified {@link Location} or
    * {@code null} if the location is unknown.
    */
-  private static String getRequestUrl(Location location) {
+   private static String getRequestUrl(Location location) {
     if (location != null) {
-      return String.format("https://api.forecast.io/forecast/%s/%f,%f", FORECAST_IO_API_KEY,
-          location.getLatitude(), location.getLongitude());
+      return String.format(Locale.US, "https://api.forecast.io/forecast/%s/%s,%s", FORECAST_IO_API_KEY,
+          getLat(location), getLong(location));
     } else {
       return null;
     }

--- a/app/src/main/java/net/maxbraun/mirror/Weather.java
+++ b/app/src/main/java/net/maxbraun/mirror/Weather.java
@@ -144,7 +144,7 @@ public class Weather extends DataUpdater<WeatherData> {
    private static String getRequestUrl(Location location) {
     if (location != null) {
       return String.format(Locale.US, "https://api.forecast.io/forecast/%s/%s,%s", FORECAST_IO_API_KEY,
-          getLat(location), getLong(location));
+          location.getLatitude(), location.getLongitude());
     } else {
       return null;
     }


### PR DESCRIPTION
Avoids 400 Bad Request as response, because getLatitude() or getLongitude() returns a floating value with comma (because the device language is set to german).